### PR TITLE
Allow to specify api server port through CLI

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -64,6 +64,7 @@ const (
 	createMount           = "mount"
 	featureGates          = "feature-gates"
 	apiServerName         = "apiserver-name"
+	apiServerPort         = "apiserver-port"
 	dnsDomain             = "dns-domain"
 	mountString           = "mount-string"
 	disableDriverMounts   = "disable-driver-mounts"
@@ -212,6 +213,7 @@ func runStart(cmd *cobra.Command, args []string) {
 	kubernetesConfig := cfg.KubernetesConfig{
 		KubernetesVersion:      selectedKubernetesVersion,
 		NodeIP:                 ip,
+		NodePort:               viper.GetInt(apiServerPort),
 		NodeName:               constants.DefaultNodeName,
 		APIServerName:          viper.GetString(apiServerName),
 		APIServerNames:         apiServerNames,
@@ -266,7 +268,7 @@ func runStart(cmd *cobra.Command, args []string) {
 		glog.Errorln("Error connecting to cluster: ", err)
 	}
 	kubeHost = strings.Replace(kubeHost, "tcp://", "https://", -1)
-	kubeHost = strings.Replace(kubeHost, ":2376", ":"+strconv.Itoa(pkgutil.APIServerPort), -1)
+	kubeHost = strings.Replace(kubeHost, ":2376", ":"+strconv.Itoa(kubernetesConfig.NodePort), -1)
 
 	fmt.Println("Setting up kubeconfig...")
 	// setup kubeconfig
@@ -389,6 +391,7 @@ func init() {
 	startCmd.Flags().String(NFSSharesRoot, "/nfsshares", "Where to root the NFS Shares (defaults to /nfsshares, only supported with hyperkit now)")
 	startCmd.Flags().StringArrayVar(&dockerEnv, "docker-env", nil, "Environment variables to pass to the Docker daemon. (format: key=value)")
 	startCmd.Flags().StringArrayVar(&dockerOpt, "docker-opt", nil, "Specify arbitrary flags to pass to the Docker daemon. (format: key=value)")
+	startCmd.Flags().Int(apiServerPort, pkgutil.APIServerPort, "The apiserver listening port")
 	startCmd.Flags().String(apiServerName, constants.APIServerName, "The apiserver name which is used in the generated certificate for kubernetes.  This can be used if you want to make the apiserver available from outside the machine")
 	startCmd.Flags().StringArrayVar(&apiServerNames, "apiserver-names", nil, "A set of apiserver names which are used in the generated certificate for kubernetes.  This can be used if you want to make the apiserver available from outside the machine")
 	startCmd.Flags().IPSliceVar(&apiServerIPs, "apiserver-ips", nil, "A set of apiserver IP Addresses which are used in the generated certificate for kubernetes.  This can be used if you want to make the apiserver available from outside the machine")

--- a/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
+++ b/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
@@ -359,6 +359,12 @@ func generateConfig(k8s config.KubernetesConfig) (string, error) {
 		return "", errors.Wrap(err, "generating extra component config for kubeadm")
 	}
 
+	// In case of no port assigned, use util.APIServerPort
+	nodePort := k8s.NodePort
+	if nodePort <= 0 {
+		nodePort = util.APIServerPort
+	}
+
 	opts := struct {
 		CertDir           string
 		ServiceCIDR       string
@@ -374,7 +380,7 @@ func generateConfig(k8s config.KubernetesConfig) (string, error) {
 		CertDir:           util.DefaultCertPath,
 		ServiceCIDR:       util.DefaultServiceCIDR,
 		AdvertiseAddress:  k8s.NodeIP,
-		APIServerPort:     util.APIServerPort,
+		APIServerPort:     nodePort,
 		KubernetesVersion: k8s.KubernetesVersion,
 		EtcdDataDir:       "/data/minikube", //TODO(r2d4): change to something else persisted
 		NodeName:          k8s.NodeName,

--- a/pkg/minikube/bootstrapper/kubeadm/kubeadm_test.go
+++ b/pkg/minikube/bootstrapper/kubeadm/kubeadm_test.go
@@ -228,6 +228,32 @@ schedulerExtraArgs:
 			},
 			shouldErr: true,
 		},
+		{
+			description: "custom api server port",
+			cfg: config.KubernetesConfig{
+				NodeIP:            "192.168.1.100",
+				NodePort:          18443,
+				KubernetesVersion: "v1.10.0",
+				NodeName:          "minikube",
+			},
+			expectedCfg: `apiVersion: kubeadm.k8s.io/v1alpha1
+kind: MasterConfiguration
+noTaintMaster: true
+api:
+  advertiseAddress: 192.168.1.100
+  bindPort: 18443
+  controlPlaneEndpoint: localhost
+kubernetesVersion: v1.10.0
+certificatesDir: /var/lib/minikube/certs/
+networking:
+  serviceSubnet: 10.96.0.0/12
+etcd:
+  dataDir: /data/minikube
+nodeName: minikube
+apiServerExtraArgs:
+  admission-control: "Initializers,NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,NodeRestriction,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota"
+`,
+		},
 	}
 
 	for _, test := range tests {

--- a/pkg/minikube/bootstrapper/kubeadm/util.go
+++ b/pkg/minikube/bootstrapper/kubeadm/util.go
@@ -171,7 +171,7 @@ func restartKubeProxy(k8s config.KubernetesConfig) error {
 		APIServerPort    int
 	}{
 		AdvertiseAddress: k8s.NodeIP,
-		APIServerPort:    util.APIServerPort,
+		APIServerPort:    k8s.NodePort,
 	}
 
 	kubeconfig := bytes.Buffer{}

--- a/pkg/minikube/config/types.go
+++ b/pkg/minikube/config/types.go
@@ -57,6 +57,7 @@ type MachineConfig struct {
 type KubernetesConfig struct {
 	KubernetesVersion string
 	NodeIP            string
+	NodePort          int
 	NodeName          string
 	APIServerName     string
 	APIServerNames    []string


### PR DESCRIPTION
Add the `--apiserver-port` CLI option in order to specify a different API port (defaults to 8443 which was the original choice).
Update the kubeadm test in order to test this new functionnality